### PR TITLE
mmvc with consensus

### DIFF
--- a/tools/mmvc/.shed.yml
+++ b/tools/mmvc/.shed.yml
@@ -1,0 +1,10 @@
+name: mmvc
+owner: iuc
+description: Multinomial mixture variant caller
+long_description: |
+  Call variants using a multinomial model sampled by MCMC
+remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/tools/mmvc/
+homepage_url: https://github.com/veg/mmvc/
+type: unrestricted
+categories:
+ - Variant Analysis

--- a/tools/mmvc/extract_mmvc_consensus
+++ b/tools/mmvc/extract_mmvc_consensus
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+
+# first argument is script name; second should be mmvcOutput path; third should be name for fasta header; the fourth argument should be the path to save the fasta at
+mmvcOutput = sys.argv[1]
+fastaHeaderName = sys.argv[2]
+fastaFilePath = sys.argv[3]
+
+with open(mmvcOutput) as f:
+    data = json.load(f)
+consensus = data["consensus"]
+consensusFasta = ">" + fastaHeaderName + "\n" + consensus
+f = open(fastaFilePath, "w")
+f.write(consensusFasta)

--- a/tools/mmvc/extract_mmvc_consensus
+++ b/tools/mmvc/extract_mmvc_consensus
@@ -11,6 +11,6 @@ fastaFilePath = sys.argv[3]
 with open(mmvcOutput) as f:
     data = json.load(f)
 consensus = data["consensus"]
-consensusFasta = ">" + fastaHeaderName + "\n" + consensus
+consensusFasta = ">" + fastaHeaderName + "\n" + consensus + "\n"
 f = open(fastaFilePath, "w")
 f.write(consensusFasta)

--- a/tools/mmvc/mmvc.xml
+++ b/tools/mmvc/mmvc.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<tool id="mmvc" version="1.0.2" name="mmvc">
+  <description>Multinomial mixture variant caller</description>
+  <requirements>
+    <requirement type="package" version="1.0.2">mmvc</requirement>
+  </requirements>
+  <stdio>
+    <exit_code range="1:"/>
+  </stdio>
+  <version_command/>
+  <command><![CDATA[
+                mmvc -j '$json_report' -f '$filter_msa'
+                #if str($options.advanced) == 'advanced':
+                                -g $options.grid_density -c $options.chain_length -b $options.burnin_fraction -t $options.target_rate -p $options.posterior_threshold
+                #end if 
+                '$input_fasta' &&
+                $__tool_directory__/extract_mmvc_consensus '$json_report' '$input_fasta.display_name' '$consensus_fasta'
+    ]]></command>
+  <inputs>
+    <param name="input_fasta" label="Input FASTA" type="data" format="fasta"/>
+    <conditional name="options">
+      <param label="Additional options" name="advanced" type="select">
+        <option value="defaults">Use defaults</option>
+        <option value="advanced">Specify additional
+        parameters</option>
+      </param>
+      <when value="defaults"/>
+      <when value="advanced">
+        <param label="GRID_DENSITY" name="grid_density" type="integer" value="10"/>
+        <param label="CHAIN_LENGTH" name="chain_length" type="integer" value="2000000"/>
+        <param label="BURNIN_FRACTION" name="burnin_fraction" type="float" value="0.5"/>
+        <param label="TARGET_RATE" name="target_rate" type="float" value="0.01"/>
+        <param label="POSTERIOR_THRESHOLD" name="posterior_threshold" type="float" value="0.95"/>
+      </when>
+    </conditional>
+  </inputs>
+  <outputs>
+    <data format="json" name="json_report"/>
+    <data format="fasta" name="filter_msa"/>
+    <data format="fasta" name="consensus_fasta"/>
+  </outputs>
+  <tests>
+    <test>
+      <param name="input_fasta" value="mmvc-in1.fa"/>
+      <param name="advanced" value="advanced"/>
+      <param name="chain_length" value="200"/>
+      <output name="json_report">
+        <assert_contents>
+          <has_text text="variant"/>
+          <has_text text="weight"/>
+        </assert_contents>
+      </output>
+    </test>
+  </tests>
+  <help><![CDATA[
+MMVC
+----
+Multinomial mixture variant caller
+    ]]></help>
+  <citations>
+    <citation type="bibtex">@UNPUBLISHED{spond, author = "Sergei
+    Kosakovsky Pond", title = "HyPhy: Hypothesis Testing using
+    Phylogenies", year = "2000", note = "http://hyphy.org/", url =
+    "http://hyphy.org/"}</citation>
+  </citations>
+</tool>


### PR DESCRIPTION
This version of the tool us up and running at http://staging.galaxy.hyphy.org

MMVC was previously only on the [mmvc branch](https://github.com/veg/tools-iuc/tree/mmvc) (unsure why)

This PR adds the mmvc tool back into the master branch and adds an additional output from the tool: the consensus sequence as a single sequence fasta with the sequence id (`>sequence_id`) being the file name of the input to mmvc (this way we can concatenate multiple consensus sequences for downstream analyses)