### PR TITLE
Fix issue with discarded reads

### DIFF
--- a/tools/bioext/bealign.xml
+++ b/tools/bioext/bealign.xml
@@ -1,108 +1,110 @@
 <?xml version="1.0"?>
 <tool id="bioext_bealign" name="Align sequences" version="@VERSION@.0">
-    <description>to a reference using a codon alignment algorithm</description>
-    <macros>
-        <import>macros.xml</import>
-    </macros>
-    <expand macro="requirements" />
-    <version_command>bealign --version</version_command>
-    <command detect_errors="exit_code">
-    <![CDATA[
+  <description>to a reference using a codon alignment
+  algorithm</description>
+  <macros>
+    <import>macros.xml</import>
+  </macros>
+  <expand macro="requirements"/>
+  <version_command>bealign --version</version_command>
+  <command detect_errors="exit_code"><![CDATA[
     bealign --reference '$select_reference.reference' --alphabet $advanced.alphabet
         #if $advanced.expected_identity:
             --expected-identity $advanced.expected_identity
         #end if
         --score-matrix $advanced.score_matrix $advanced.reverse_complement $advanced.keep_reference
         #if $advanced.discard:
-            $advanced.discard '$advanced.discarded_reads'
+            --discard '$discarded_reads'
         #end if
         '$input' '$output'
-    ]]>
-    </command>
-    <inputs>
-        <param name="input" type="data" format="fasta" label="Input reads" />
-        <conditional name="select_reference">
-            <param name="reference_type" type="select">
-                <option value="preset">Select preset</option>
-                <option value="dataset">Use a history dataset</option>
-            </param>
-            <when value="preset">
-                <param argument="--reference" type="select">
-                    <option value="HXB2_tat">HXB2 tat</option>
-                    <option value="HXB2_gag">HXB2 gag</option>
-                    <option value="HXB2_pol">HXB2 polymerase</option>
-                    <option value="HXB2_int">HXB2 integrase</option>
-                    <option value="HXB2_vif">HXB2 vif</option>
-                    <option value="HXB2_pr">HXB2 protease</option>
-                    <option value="HXB2_vpr">HXB2 vpr</option>
-                    <option value="NL4-3_prrt">NL4-3 protease and reverse transcriptase</option>
-                    <option value="HXB2_nef">HXB2 nef</option>
-                    <option value="HXB2_env">HXB2 envelope</option>
-                    <option value="HXB2_rt">HXB2 reverse transcriptase</option>
-                    <option value="HXB2_prrt">HXB2 protease and reverse transcriptase</option>
-                    <option value="HXB2_rev">HXB2 rev</option>
-                    <option value="HXB2_vpu">HXB2 vpu</option>
-                </param>
-            </when>
-            <when value="dataset">
-                <param argument="--reference" type="data" format="fasta" label="Reference sequences" />
-            </when>
-        </conditional>
-        <section name="advanced" title="Advanced options" expanded="False">
-            <param name="expected_identity" argument="--expected-identity" type="float" min="0" max="1" optional="True" label="Discard sequences that are insufficiently identical to the reference" />
-            <param argument="--alphabet" type="select" label="Alphabet to use for alignment">
-                <option value="codon" selected="True">Codon</option>
-                <option value="dna">DNA</option>
-                <option value="amino">Amino acids</option>
-            </param>
-            <param name="score_matrix" argument="--score-matrix" type="select" label="Parametrize using score matrix">
-                <option value="BLOSUM62" selected="True">Blocks substitution</option>
-                <option value="DNA65">DNA, 65% expected identity</option>
-                <option value="DNA70">DNA, 70% expected identity</option>
-                <option value="DNA88">DNA, 88% expected identity</option>
-                <option value="DNA80">DNA, 80% expected identity</option>
-                <option value="DNA95">DNA, 95% expected identity</option>
-                <option value="PAM200">PAM 200 substitution</option>
-                <option value="PAM250">PAM 250 substitution</option>
-                <option value="HIV_BETWEEN_F">HIV between+F</option>
-            </param>
-            <param argument="--discard" type="boolean" checked="False" truevalue="--discard" falsevalue="" label="Output discarded sequences to a separate dataset" />
-            <param name="reverse_complement" argument="--reverse-complement" type="boolean" checked="False" truevalue="--reverse-complement" falsevalue="" label="Also try to align against reverse complement of reference" />
-            <param name="keep_reference" argument="--keep-reference" type="boolean" checked="False" truevalue="--keep-reference" falsevalue="" label="Include reference as first sequence in aligned BAM" />
-        </section>
-    </inputs>
-    <outputs>
-        <data name="output" format="bam" />
-        <data name="discarded_reads" format="fasta">
-            <filter>advanced['discard']</filter>
-        </data>
-    </outputs>
-    <tests>
-        <test>
-            <param name="input" ftype="fasta" value="bealign-in1.fa" />
-            <param name="reference_type" value="dataset" />
-            <param name="score_matrix" value="HIV_BETWEEN_F" />
-            <param name="reference" ftype="fasta" value="bealign-in-ref-1.fa" />
-            <output name="output" file="bealign-out1.bam" />
-        </test>
-        <test>
-            <param name="input" ftype="fasta" value="bealign-in2.fa" />
-            <param name="reference_type" value="dataset" />
-            <param name="score_matrix" value="BLOSUM62" />
-            <param name="reference" ftype="fasta" value="bealign-in-ref-2.fa" />
-            <output name="output" file="bealign-out2.bam" />
-        </test>
-        <test>
-            <param name="input" ftype="fasta" value="bealign-in2.fa" />
-            <param name="reference_type" value="dataset" />
-            <param name="expected_identity" value="0.9" />
-            <param name="score_matrix" value="BLOSUM62" />
-            <param name="reference" ftype="fasta" value="bealign-in-ref-2.fa" />
-            <output name="output" file="bealign-out3.bam" />
-        </test>
-    </tests>
-    <help>
-    <![CDATA[
+    ]]></command>
+  <inputs>
+    <param name="input" type="data" format="fasta" label="Input reads"/>
+    <conditional name="select_reference">
+      <param name="reference_type" type="select">
+        <option value="preset">Select preset</option>
+        <option value="dataset">Use a history dataset</option>
+      </param>
+      <when value="preset">
+        <param argument="--reference" type="select">
+          <option value="HXB2_tat">HXB2 tat</option>
+          <option value="HXB2_gag">HXB2 gag</option>
+          <option value="HXB2_pol">HXB2 polymerase</option>
+          <option value="HXB2_int">HXB2 integrase</option>
+          <option value="HXB2_vif">HXB2 vif</option>
+          <option value="HXB2_pr">HXB2 protease</option>
+          <option value="HXB2_vpr">HXB2 vpr</option>
+          <option value="NL4-3_prrt">NL4-3 protease and reverse
+          transcriptase</option>
+          <option value="HXB2_nef">HXB2 nef</option>
+          <option value="HXB2_env">HXB2 envelope</option>
+          <option value="HXB2_rt">HXB2 reverse
+          transcriptase</option>
+          <option value="HXB2_prrt">HXB2 protease and reverse
+          transcriptase</option>
+          <option value="HXB2_rev">HXB2 rev</option>
+          <option value="HXB2_vpu">HXB2 vpu</option>
+        </param>
+      </when>
+      <when value="dataset">
+        <param argument="--reference" type="data" format="fasta" label="Reference sequences"/>
+      </when>
+    </conditional>
+    <section name="advanced" title="Advanced options" expanded="False">
+      <param name="expected_identity" argument="--expected-identity" type="float" min="0" max="1" optional="True" label="Discard sequences that are insufficiently identical to the reference"/>
+      <param argument="--alphabet" type="select" label="Alphabet to use for alignment">
+        <option value="codon" selected="True">Codon</option>
+        <option value="dna">DNA</option>
+        <option value="amino">Amino acids</option>
+      </param>
+      <param name="score_matrix" argument="--score-matrix" type="select" label="Parametrize using score matrix">
+        <option value="BLOSUM62" selected="True">Blocks
+        substitution</option>
+        <option value="DNA65">DNA, 65% expected identity</option>
+        <option value="DNA70">DNA, 70% expected identity</option>
+        <option value="DNA88">DNA, 88% expected identity</option>
+        <option value="DNA80">DNA, 80% expected identity</option>
+        <option value="DNA95">DNA, 95% expected identity</option>
+        <option value="PAM200">PAM 200 substitution</option>
+        <option value="PAM250">PAM 250 substitution</option>
+        <option value="HIV_BETWEEN_F">HIV between+F</option>
+      </param>
+      <param name="discard" argument="--discard" type="boolean" checked="False" truevalue="True" falsevalue="False" label="Output discarded sequences to a separate dataset"/>
+      <param name="reverse_complement" argument="--reverse-complement" type="boolean" checked="False" truevalue="--reverse-complement" falsevalue="" label="Also try to align against reverse complement of reference"/>
+      <param name="keep_reference" argument="--keep-reference" type="boolean" checked="False" truevalue="--keep-reference" falsevalue="" label="Include reference as first sequence in aligned BAM"/>
+    </section>
+  </inputs>
+  <outputs>
+    <data name="output" format="bam"/>
+    <data name="discarded_reads" format="fasta">
+      <filter>advanced['discard']</filter>
+    </data>
+  </outputs>
+  <tests>
+    <test>
+      <param name="input" ftype="fasta" value="bealign-in1.fa"/>
+      <param name="reference_type" value="dataset"/>
+      <param name="score_matrix" value="HIV_BETWEEN_F"/>
+      <param name="reference" ftype="fasta" value="bealign-in-ref-1.fa"/>
+      <output name="output" file="bealign-out1.bam"/>
+    </test>
+    <test>
+      <param name="input" ftype="fasta" value="bealign-in2.fa"/>
+      <param name="reference_type" value="dataset"/>
+      <param name="score_matrix" value="BLOSUM62"/>
+      <param name="reference" ftype="fasta" value="bealign-in-ref-2.fa"/>
+      <output name="output" file="bealign-out2.bam"/>
+    </test>
+    <test>
+      <param name="input" ftype="fasta" value="bealign-in2.fa"/>
+      <param name="reference_type" value="dataset"/>
+      <param name="expected_identity" value="0.9"/>
+      <param name="score_matrix" value="BLOSUM62"/>
+      <param name="reference" ftype="fasta" value="bealign-in-ref-2.fa"/>
+      <output name="output" file="bealign-out3.bam"/>
+    </test>
+  </tests>
+  <help><![CDATA[
 bealign
 -------
 
@@ -113,5 +115,5 @@ NOTES
 
 Reference can be one of the presets or a custom history reference.
     ]]></help>
-    <expand macro="citations"/>
+  <expand macro="citations"/>
 </tool>


### PR DESCRIPTION
Addresses #68 

See this data history for documentation of the fix: https://staging.galaxy.hyphy.org:/u/rdvelazquez/h/bealignteststaging
datasets 5 and 6 were before the fix; 7+ were after.

The fixed tool is now live on galaxy.hyphy.org

Not sure why the formatting is so screwy (throwing off the git diff)... this just changes lines 17 and 69 (old line numbers) 